### PR TITLE
Add ability to search multiple terms

### DIFF
--- a/src/app/phase-bug-reporting/phase-bug-reporting.component.html
+++ b/src/app/phase-bug-reporting/phase-bug-reporting.component.html
@@ -10,7 +10,7 @@
 
     <mat-grid-tile>
       <mat-form-field class="full-grid-width">
-        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" />
+        <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search (use ; as delimiter)" />
       </mat-form-field>
     </mat-grid-tile>
 

--- a/src/app/shared/issue-tables/search-filter.ts
+++ b/src/app/shared/issue-tables/search-filter.ts
@@ -2,28 +2,38 @@ import { Issue } from '../../core/models/issue.model';
 import { IssueService } from '../../core/services/issue.service';
 import { TABLE_COLUMNS } from './issue-tables-columns';
 
+const DELIMITER = ';';
+
 /**
  * This module serves to improve separation of concerns in IssuesDataTable.ts module by containing the logic for
  * applying search filter to the issues data table in this module.
  * This module exports a single function applySearchFilter which is called by IssuesDataTable.
  */
 export function applySearchFilter(filter: string, displayedColumn: string[], issueService: IssueService, data: Issue[]): Issue[] {
-  const searchKey = filter.toLowerCase();
+  const filters: string[] = filter.split(DELIMITER).filter((filter) => filter !== '');
+  const hasNonEmptyFilters: boolean = filters.length > 0;
+
+  if (!hasNonEmptyFilters) {
+    return data.slice();
+  }
+
+  const searchKeys: string[] = filters.map((filter) => filter.toLowerCase());
+
   const result = data.slice().filter((issue: Issue) => {
     for (const column of displayedColumn) {
       switch (column) {
         case TABLE_COLUMNS.ASSIGNEE:
-          if (matchesAssignee(issue.assignees, searchKey)) {
+          if (matchesAssignee(issue.assignees, searchKeys)) {
             return true;
           }
           break;
         case TABLE_COLUMNS.DUPLICATED_ISSUES:
-          if (matchesDuplicatedIssue(issueService, issue.id, searchKey)) {
+          if (matchesDuplicatedIssue(issueService, issue.id, searchKeys)) {
             return true;
           }
           break;
         default:
-          if (matchesOtherColumns(issue, column, searchKey)) {
+          if (matchesOtherColumns(issue, column, searchKeys)) {
             return true;
           }
           break;
@@ -34,24 +44,24 @@ export function applySearchFilter(filter: string, displayedColumn: string[], iss
   return result;
 }
 
-function containsSearchKey(item: string, searchKey: string): boolean {
-  return item.indexOf(searchKey) !== -1;
+function containsSearchKey(item: string, searchKeys: string[]): boolean {
+  return searchKeys.some((searchKey) => item.indexOf(searchKey) !== -1);
 }
 
-function duplicatedIssuesContainsSearchKey(duplicatedIssues: Issue[], searchKey: string): boolean {
-  return duplicatedIssues.filter((el) => `#${String(el.id)}`.includes(searchKey)).length !== 0;
+function duplicatedIssuesContainsSearchKey(duplicatedIssues: Issue[], searchKeys: string[]): boolean {
+  return duplicatedIssues.some((el) => searchKeys.some((searchKey) => `#${String(el.id)}`.includes(searchKey)));
 }
 
-function matchesAssignee(assignees: string[], searchKey: string): boolean {
-  return assignees.some((assignee) => containsSearchKey(assignee.toLowerCase(), searchKey));
+function matchesAssignee(assignees: string[], searchKeys: string[]): boolean {
+  return assignees.some((assignee) => containsSearchKey(assignee.toLowerCase(), searchKeys));
 }
 
-function matchesDuplicatedIssue(issueService: IssueService, id: number, searchKey: string): boolean {
+function matchesDuplicatedIssue(issueService: IssueService, id: number, searchKeys: string[]): boolean {
   const duplicatedIssues = issueService.issues$.getValue().filter((el) => el.duplicateOf === id);
-  return duplicatedIssuesContainsSearchKey(duplicatedIssues, searchKey);
+  return duplicatedIssuesContainsSearchKey(duplicatedIssues, searchKeys);
 }
 
-function matchesOtherColumns(issue: Issue, column: string, searchKey: string): boolean {
+function matchesOtherColumns(issue: Issue, column: string, searchKeys: string[]): boolean {
   const searchStr = String(issue[column]).toLowerCase();
-  return containsSearchKey(searchStr, searchKey);
+  return containsSearchKey(searchStr, searchKeys);
 }


### PR DESCRIPTION
### Summary:
Enhance search field to allow searching for multiple fields at the same time.

### Changes Made:
* Add ability to search multiple terms in the search field.
  * For example, when searching `high;documentation`, it will include results that would previously match *either* `high` or `documentation`.
* If logical *AND* would be preferred instead, it would be simple to tweak this feature for that.

![image](https://github.com/seetohjinwei/CATcher/assets/47915290/976f50fd-4cf7-4c1c-8e0e-28a07f5e7210)

### Proposed Commit Message:
```
Add ability to search multiple terms

Let's
* Improve the search filter to allow searching of multiple terms.
* Add a hint in the placeholder of the search field.
```
